### PR TITLE
Default Params for Requests

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -153,7 +153,7 @@ function postRequest(
   route,
   successFunc,
   errorFunc,
-  params = "{}",
+  params = {},
   shouldUseAltRoute = false
 ) {
   return request(
@@ -173,7 +173,7 @@ function postRequestNoCatch(
   route,
   successFunc,
   errorFunc,
-  params = "{}",
+  params = {},
   shouldUseAltRoute = false
 ) {
   return requestNoCatch(
@@ -193,7 +193,7 @@ function putRequest(
   route,
   successFunc,
   errorFunc,
-  params = "{}",
+  params = {},
   shouldUseAltRoute = false
 ) {
   return request(
@@ -213,7 +213,7 @@ function putRequestNoCatch(
   route,
   successFunc,
   errorFunc,
-  params = "{}",
+  params = {},
   shouldUseAltRoute = false
 ) {
   return requestNoCatch(
@@ -233,7 +233,7 @@ function deleteRequest(
   route,
   successFunc,
   errorFunc,
-  params = "{}",
+  params = {},
   shouldUseAltRoute = false
 ) {
   return request(


### PR DESCRIPTION
Changing default params for requests to be empty objects and not strings.